### PR TITLE
feat:page에 Id 추가하기

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,11 +22,23 @@ function App() {
           <Route path="/history" element={<ReservationHistoryPage />}></Route>
         </Route>
         <Route path="/login" element={<LoginPage />}></Route>
-        <Route path="/carwashdetail" element={<CarwashDetailPage />}></Route>
-        <Route path="/bayselection" element={<BaySelectionPage />}></Route>
-        <Route path="/schedule" element={<SchedulePage />}></Route>
-        <Route path="/payment" element={<PaymentPage />}></Route>
-        <Route path="/paymentresult" element={<PaymentResultPage />}></Route>
+        <Route
+          path="/carwashdetail/:carwashId"
+          element={<CarwashDetailPage />}
+        ></Route>
+        <Route
+          path="/bayselection/:carwashId"
+          element={<BaySelectionPage />}
+        ></Route>
+        <Route
+          path="/schedule/:carwashId/:bayId"
+          element={<SchedulePage />}
+        ></Route>
+        <Route path="/payment/:reservationId" element={<PaymentPage />}></Route>
+        <Route
+          path="/paymentresult/:reservationId"
+          element={<PaymentResultPage />}
+        ></Route>
         <Route path="/reviewpost" element={<ReviewPostPage />}></Route>
       </Routes>
     </BrowserRouter>

--- a/src/apis/reservations.js
+++ b/src/apis/reservations.js
@@ -3,6 +3,10 @@ import { instance } from "./instance";
 export const reservations = () => {
   return instance.get("/reservations");
 };
+// 나중에 api 수정되면 이거로 바꾸기
+// export const reservations = (reservationId) => {
+//   return instance.get(`/reservations/${reservationId}`);
+// };
 export const reservationsCurrentstatus = () => {
   return instance.get("/reservations/current-status");
 };

--- a/src/components/atoms/Button.jsx
+++ b/src/components/atoms/Button.jsx
@@ -1,58 +1,19 @@
 import React from "react";
-export const Button = ({
-  type = "long",
-  className,
-  onClick,
-  label,
-  icon,
-  href,
-  ...props
-}) => {
-  const handleButtonClick = () => {
-    if (type === "cancel") {
-      // 여기서 팝업을 트리거할 수 있습니다.
-      onClick(); // onClick prop은 모달 디스플레이 로직을 처리한다고 가정합니다.
-    } else if (type === "review") {
-      window.location.href = "/reviewpost"; // 이것은 reviewpost 페이지로 리다이렉트합니다.
-    }
-    if (type === "reviewpost") {
-      onClick();
-    }
-    if (type === "cancelreservation") {
-      onClick();
-    }
-    if (type === "home") {
-      onClick();
-    }
+
+export const Button = ({ variant, className, children, ...props }) => {
+  const styles = {
+    long: "block w-full h-14 p-4 bg-primary text-white font-semibold rounded-none",
+    small: "block w-28 h-14 bg-sky-100 text-sky-500 font-semibold rounded-xl",
+    home: "relative flex items-start w-full h-20 bg-white p-4 text-left break-keep overflow-hidden shadow-xl rounded-xl",
+    cancel:
+      "w-12 h-20 px-2 py-5 rounded-xl items-center text-white text-xs bg-slate-500 ml-auto mr-4",
+    review:
+      "w-12 h-20 px-2 py-5 rounded-xl items-center text-white text-xs bg-red-400 ml-auto mr-4",
   };
-  const getType = (type) => {
-    switch (type) {
-      case "long":
-        return "block w-full h-14 p-4 bg-primary text-white font-semibold rounded-none";
-      case "small":
-        return "block w-28 h-14 bg-sky-100 text-sky-500 font-semibold rounded-xl";
-      case "home":
-        return "relative flex items-start w-full h-20 bg-white p-4 text-left break-keep overflow-hidden shadow-xl rounded-xl";
-      case "cancel":
-        return "w-12 h-20 px-2 py-5 rounded-xl items-center text-white text-xs bg-slate-500 ml-auto mr-4";
-      case "review":
-        return "w-12 h-20 px-2 py-5 rounded-xl items-center text-white text-xs bg-red-400 ml-auto mr-4";
-      case "reviewpost":
-        return "block w-full h-14 p-4 bg-primary text-white font-semibold rounded-none";
-      case "cancelreservation":
-        return "block w-full h-14 p-4 bg-primary text-white font-semibold rounded-none";
-    }
-  };
+
   return (
-    <button
-      type="button"
-      href={href}
-      className={`${getType(type)} ${className}`}
-      onClick={handleButtonClick}
-      {...props}
-    >
-      <img src={icon} className="absolute right-4 bottom-4" />
-      {label}
+    <button className={`${styles[variant]} ${className}`} {...props}>
+      {children}
     </button>
   );
 };

--- a/src/components/templates/BaySelectionTemplate.jsx
+++ b/src/components/templates/BaySelectionTemplate.jsx
@@ -6,18 +6,19 @@ import { useEffect, useState } from "react";
 import { carwashesBays } from "../../apis/carwashes";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
-const BaySelectionTemplate = ({}) => {
+const BaySelectionTemplate = ({ carwashId }) => {
   const name = "포세이돈워시 용봉점";
   const openingHours = {
     weekday: { start: "00:00", end: "24:00" },
     weekend: { start: "00:00", end: "24:00" },
   };
   const [bayList, setBayList] = useState([]);
-
   const { data } = useSuspenseQuery({
-    queryKey: ["baylists"],
-    queryFn: carwashesBays,
+    queryKey: ["baylists", carwashId],
+    queryFn: () => carwashesBays(carwashId),
+    enabled: !!carwashId,
   });
+  console.log(data);
   useEffect(() => {
     if (data) {
       setBayList(data.data.response.bayList);

--- a/src/components/templates/CarwashDetailTemplate.jsx
+++ b/src/components/templates/CarwashDetailTemplate.jsx
@@ -1,23 +1,21 @@
-import React from "react";
 import ImageCarousel from "../atoms/ImageCarousel";
 import StoreInfo from "../atoms/StoreInfo";
 import KeyPointInfo from "../atoms/KeyPointInfo";
-import { Tab } from "../molecules/Tab";
 import { Button } from "../atoms/Button";
 import Star from "../atoms/Star";
+import { Tab } from "../molecules/Tab";
+
 import { useEffect, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { carwashesInfo } from "../../apis/carwashes";
 
-const CarwashDetailTemplate = () => {
+const CarwashDetailTemplate = ({ carwashId }) => {
   const [detaildata, setData] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [carwashesid, setCarwashid] = useState(3);
 
   const { data } = useSuspenseQuery({
-    queryKey: ["getCarwashesInfo", carwashesid], // add location to the dependency list to re-run query if location changes
-    queryFn: () => carwashesInfo(carwashesid), // Pass location to the getcarwashes_nearby function
-    enabled: !!carwashesid, // Only run the query when we have carwashid
+    queryKey: ["getCarwashesInfo", carwashId], // add location to the dependency list to re-run query if location changes
+    queryFn: () => carwashesInfo(carwashId), // Pass location to the getcarwashes_nearby function
+    enabled: !!carwashId, // Only run the query when we have carwashid
   });
 
   useEffect(() => {

--- a/src/components/templates/HomeTemplate.jsx
+++ b/src/components/templates/HomeTemplate.jsx
@@ -20,9 +20,7 @@ const HomeTemplate = () => {
     timeout: 1000,
     maximumAge: 1000,
   };
-
   const { location, error } = useGeoLocation(geolocationOptions);
-
   const [recommended, recent] = useSuspenseQueries({
     queries: [
       {
@@ -36,51 +34,41 @@ const HomeTemplate = () => {
       },
     ],
   });
-
   const recommendedData = recommended?.data?.data?.response;
   const recentList = recent?.data?.data?.response?.recent;
-
   const navigate = useNavigate();
-
   return (
     <main className="grid gap-6">
       <h1 className="text-2xl font-semibold">노주영님 안녕하세요!</h1>
       {/* 메뉴 링크 */}
       <section className="flex justify-between gap-4">
         <Button
-          type="home"
           variant="home"
           onClick={() => {
             navigate("/reservation");
           }}
-          label="내 주변 세차장 예약하기"
-          icon="/Button/home/reservation.svg"
         >
           내 주변 세차장 예약하기
-          {/* <img
+          <img
             className="absolute right-4 -bottom-4"
             src={Reservation}
             alt="위치 아이콘"
-          /> */}
+          />
         </Button>
         <Button
-          type="home"
           variant="home"
           onClick={() => {
             navigate("/history");
           }}
-          label="예약내역 보기"
-          icon="/Button/home/reservationHistory.svg"
         >
           예약내역 보기
-          {/* <img
+          <img
             className="absolute right-4 -bottom-4"
             src={ReservationHistory}
             alt="예약내역 아이콘"
-          /> */}
+          />
         </Button>
       </section>
-
       {/* 이런 세차장 어때요? */}
       <section className="grid gap-4">
         <h2 className="text-xl font-semibold">이런 세차장 어때요?</h2>
@@ -93,7 +81,6 @@ const HomeTemplate = () => {
           distance={recommendedData.distance}
         />
       </section>
-
       {/* 최근 이용 내역 */}
       <section className="grid gap-4">
         <h2 className="text-xl font-semibold">최근 이용 내역</h2>
@@ -102,5 +89,4 @@ const HomeTemplate = () => {
     </main>
   );
 };
-
 export default HomeTemplate;

--- a/src/components/templates/PaymentResultTemplate.jsx
+++ b/src/components/templates/PaymentResultTemplate.jsx
@@ -12,11 +12,14 @@ const iconsrc = {
   price: "TextWithIcon/price.png",
 };
 
-const PaymentResultTemplate = () => {
+const PaymentResultTemplate = ({ reservationId }) => {
   const [paymentresult, setpaymentresult] = useState(null);
   const [loading, setLoading] = useState(false);
 
   const { data } = useSuspenseQuery({
+    // 나중에 reservation api에 reservationId 추가 되면 이거로 코드 바꾸기
+    // queryKey: ["getReservations", reservationId],
+    // queryFn: () => reservations(reservationId),
     queryKey: ["getReservations"],
     queryFn: () => reservations(),
   });

--- a/src/components/templates/PaymentTemplate.jsx
+++ b/src/components/templates/PaymentTemplate.jsx
@@ -3,15 +3,16 @@ import { useEffect, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { paymentResult } from "../../apis/reservations";
 
-const PaymentTemplate = ({}) => {
+const PaymentTemplate = ({ reservationId }) => {
   const [paymentdata, setData] = useState(null);
-  const [reservationId, setReservation] = useState(3);
 
   const { data } = useSuspenseQuery({
     queryKey: ["getPayment", reservationId],
     queryFn: () => paymentResult(reservationId),
     enabled: !!reservationId,
   });
+  // 이 윗 부분 나중에는 삭제하기 어차피 전역변수로 SchedulePage에서 필요한 것들 다 가지고 올 것임
+  // 대신 결제 금액 계산 api 추가되면 거기에 해당하는 api 새로 가져오기
 
   useEffect(() => {
     if (data) {

--- a/src/components/templates/ScheduleTemplate.jsx
+++ b/src/components/templates/ScheduleTemplate.jsx
@@ -11,18 +11,16 @@ import {
   carwashesBays,
   bookCarwash,
 } from "../../apis/carwashes";
-const ScheduleTemplate = () => {
+const ScheduleTemplate = ({ carwashId, bayId }) => {
   const [date, setDate] = useState(new Date());
   const [startTime, setStartTime] = useState();
   const [duration, setDuration] = useState();
-  const [carwashId, setcarwashId] = useState(3);
-  const [bayId, setbayId] = useState(0);
   const navigate = useNavigate();
   const [washinfo, bayinfo] = useSuspenseQueries({
     queries: [
       {
         queryKey: ["washinfo"],
-        queryFn: () => carwashesInfo(carwashId), //나중에 전역변수로 대체
+        queryFn: () => carwashesInfo(carwashId),
       },
       {
         queryKey: ["bayinfo"],
@@ -60,8 +58,6 @@ const ScheduleTemplate = () => {
   const name = washinfo?.data?.data?.response?.name;
   const openingHours = washinfo?.data?.data?.response?.optime;
 
-  // 임의로 0을 넣어놓음.
-  //나중에는 몇 번째 베이를 선택했는지 bayselection에서 넘겨줘서 0을 대체해야 할 것 같음
   const bayInfo = bayinfo?.data?.data?.response.bayList[bayId];
 
   const handleDateChange = (date) => {

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -481,6 +481,9 @@ export const handlers = [
   // 결제가 완료된 다음에 보여주는 페이지에서 호출
   // 결제가 확실히 success 되어야 보여줘야 함
   rest.get("/reservations", (req, res, ctx) => {
+    // 나중에 api 수정 되면 이거로 바꾸기
+    // rest.get("/reservations/:reservationId", (req, res, ctx) => {
+    // const { reservationId } = req.params;
     const token = req.headers.get("Authorization");
 
     if (!token) {

--- a/src/pages/BaySelectionPage.jsx
+++ b/src/pages/BaySelectionPage.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { Suspense } from "react";
+import { useParams } from "react-router-dom";
 import BaySelectionTemplate from "../components/templates/BaySelectionTemplate";
 const BaySelectionPage = () => {
+  const { carwashId } = useParams(); //string
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <BaySelectionTemplate />
+      <BaySelectionTemplate carwashId={carwashId} />
     </Suspense>
   );
 };

--- a/src/pages/CarwashDetailPage.jsx
+++ b/src/pages/CarwashDetailPage.jsx
@@ -1,9 +1,11 @@
 import { Suspense } from "react";
+import { useParams } from "react-router-dom";
 import CarwashDetailTemplate from "../components/templates/CarwashDetailTemplate";
 const CarwashDetailPage = () => {
+  const { carwashId } = useParams();
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <CarwashDetailTemplate />
+      <CarwashDetailTemplate carwashId={carwashId} />
     </Suspense>
   );
 };

--- a/src/pages/PaymentPage.jsx
+++ b/src/pages/PaymentPage.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { Suspense } from "react";
+import { useParams } from "react-router-dom";
 import PaymentTemplate from "../components/templates/PaymentTemplate";
 const PaymentPage = () => {
+  const { reservationId } = useParams();
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <PaymentTemplate />
+      <PaymentTemplate reservationId={reservationId} />
     </Suspense>
   );
 };

--- a/src/pages/PaymentResultPage.jsx
+++ b/src/pages/PaymentResultPage.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { Suspense } from "react";
+import { useParams } from "react-router-dom";
 import PaymentResultTemplate from "../components/templates/PaymentResultTemplate.jsx";
 const PaymentResultPage = () => {
+  const { reservationId } = useParams(); //string
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <PaymentResultTemplate />
+      <PaymentResultTemplate reservationId={reservationId} />
     </Suspense>
   );
 };

--- a/src/pages/ReviewPostPage.jsx
+++ b/src/pages/ReviewPostPage.jsx
@@ -1,6 +1,8 @@
 import ReviewPostTemplate from "../components/templates/ReviewPostTemplate";
 import { Suspense } from "react";
+import { useParams } from "react-router-dom";
 const ReviewPostPage = () => {
+  const { reservationId } = useParams();
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <ReviewPostTemplate />

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { Suspense } from "react";
+import { useParams } from "react-router-dom";
 import ScheduleTemplate from "../components/templates/ScheduleTemplate";
 const SchedulePage = () => {
+  const { carwashId, bayId } = useParams(); //string
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <ScheduleTemplate />
+      <ScheduleTemplate carwashId={carwashId} bayId={bayId} />
     </Suspense>
   );
 };


### PR DESCRIPTION
## Motivation
- 왜 변경했는지
Carwashid나 bayid, reservationid를 사용해서 구현해야 하는 페이지들이 있기 때문에
## Key Changes
- Button 컴포넌트, HomeTemplate 다시 간결한 상태로 롤백
대신 HistoryPage의 버튼 컴포넌트는 사라진 상태, 나중에 간결한 Button컴포넌트에 맞춰 수정하기
- App.jsx =>  
.....Page.jsx에서 useParams로 App.jsx 경로의 파라미터를 가져옴=> 
....Template으로 가져온 값을 전달
## To Reviewers
- 현재 수정 요청한 PaymentResultPage (api 경로에 :reservationId  추가 요청했음)의 경우
나중에 바꿀 코드 주석처리로 해 놓음
- PaymentPage의 경우, 기존 api 문서에 맞게 :reservationId로 경로가 되어있긴 한데,
아마 Schedule 페이지에서 필요한 전역변수를 다 가져올 것이기 때문에
(결제 금액 계산해주는 api가 추가되어도 id값을 사용하지 않음)
주소 쿼리에 넣은 reservationId를 나중엔 빼도 괜찮을 것 같음
