### PR TITLE
Feat/state 전역 상태 관리 및 버그 수정 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bdbd-user",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.7",
         "@tanstack/react-query": "^5.0.0",
         "axios": "^1.5.1",
         "dayjs": "^1.11.10",
@@ -16,10 +17,13 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.47.0",
         "react-icons": "^4.11.0",
+        "react-redux": "^8.1.3",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.16.0",
         "react-spring": "^9.7.3",
-        "react-use-gesture": "^9.1.3"
+        "react-use-gesture": "^9.1.3",
+        "redux": "^4.2.1",
+        "redux-persist": "^6.0.0"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.4.5",
@@ -4876,6 +4880,29 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
@@ -6938,6 +6965,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
+      "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
@@ -7071,7 +7107,7 @@
       "version": "18.2.8",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
       "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7137,6 +7173,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.25",
@@ -11596,6 +11637,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -11720,6 +11769,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -16436,6 +16494,49 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -16797,6 +16898,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -16958,6 +17083,11 @@
       "engines": {
         "node": ">=0.10.5"
       }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -18941,7 +19071,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.7",
     "@tanstack/react-query": "^5.0.0",
     "axios": "^1.5.1",
     "dayjs": "^1.11.10",
@@ -20,10 +21,13 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",
     "react-icons": "^4.11.0",
+    "react-redux": "^8.1.3",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.16.0",
     "react-spring": "^9.7.3",
-    "react-use-gesture": "^9.1.3"
+    "react-use-gesture": "^9.1.3",
+    "redux": "^4.2.1",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.4.5",

--- a/src/components/atoms/Button.jsx
+++ b/src/components/atoms/Button.jsx
@@ -5,10 +5,8 @@ export const Button = ({ variant, className, children, ...props }) => {
     long: "block w-full h-14 p-4 bg-primary text-white font-semibold rounded-none",
     small: "block w-28 h-14 bg-sky-100 text-sky-500 font-semibold rounded-xl",
     home: "relative flex items-start w-full h-20 bg-white p-4 text-left break-keep overflow-hidden shadow-xl rounded-xl",
-    cancel:
-      "w-12 h-20 px-2 py-5 rounded-xl items-center text-white text-xs bg-slate-500 ml-auto mr-4",
-    review:
-      "w-12 h-20 px-2 py-5 rounded-xl items-center text-white text-xs bg-red-400 ml-auto mr-4",
+    cancel: "w-16 h-12 px-4 bg-red-500 text-white text-sm  rounded-md",
+    review: "w-16 h-12 px-4 bg-primary text-white text-sm  rounded-md",
   };
 
   return (

--- a/src/components/atoms/GNB.jsx
+++ b/src/components/atoms/GNB.jsx
@@ -35,7 +35,7 @@ export const GNB = () => {
     },
     {
       name: "예약내역",
-      path: "/reservationlist",
+      path: "/history",
       icon: ReservationList,
       iconActive: ReservationListActive,
     },
@@ -58,7 +58,8 @@ export const GNB = () => {
                     currentPage === menu.path
                       ? "text-sky-500 text-xs"
                       : "text-xs"
-                  }>
+                  }
+                >
                   {menu.name}
                 </div>
               </div>

--- a/src/components/atoms/ImageCarousel.jsx
+++ b/src/components/atoms/ImageCarousel.jsx
@@ -11,7 +11,7 @@ const ImageCarousel = ({ images }) => {
 
   const renderSlides = images.map((image, index) => (
     <div key={index}>
-      <img src={image.url} alt={image.alt} />
+      <img src={image.url} alt={image.alt} className="h-56" />
     </div>
   ));
 
@@ -26,7 +26,6 @@ const ImageCarousel = ({ images }) => {
         showThumbs={false}
         selectedItem={images[currentIndex]}
         onChange={handleChange}
-        className="w-full mb-2 h-4/5"
       >
         {renderSlides}
       </Carousel>

--- a/src/components/atoms/StoreInfo.jsx
+++ b/src/components/atoms/StoreInfo.jsx
@@ -5,6 +5,25 @@ import MapImage from "/StoreInfo/Map.svg";
 import TelImage from "/StoreInfo/Tel.svg";
 
 const StoreInfo = ({ weekhour, weekendhour, tel, address }) => {
+  // 전화번호에 하이픈
+  const formatPhoneNumber = (phoneNumber) => {
+    const digits = phoneNumber.replace(/\D/g, "");
+
+    if (digits.length === 11) {
+      return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(
+        7,
+        11
+      )}`;
+    } else if (digits.length === 10) {
+      return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(
+        6,
+        10
+      )}`;
+    } else {
+      return phoneNumber;
+    }
+  };
+
   return (
     <div className="grid gap-2 p-4 bg-gray-100 rounded-lg">
       <div className="flex items-center gap-2">
@@ -17,7 +36,7 @@ const StoreInfo = ({ weekhour, weekendhour, tel, address }) => {
       <div className="flex items-center gap-2">
         <Image src={TelImage} alt="전화번호" />
         <a href={`tel:${tel}`} className="text-xs text-primary">
-          {tel}
+          {formatPhoneNumber(tel)}
         </a>
       </div>
       <div className="flex items-center gap-2">

--- a/src/components/atoms/TextWithIcon.jsx
+++ b/src/components/atoms/TextWithIcon.jsx
@@ -3,15 +3,13 @@
  * @param text : 들어갈 문구
  */
 
+import Image from "./Image";
+
 export const TextWithIcon = ({ iconsrc, text, className }) => {
   return (
-    <div className={`h-6 items-left gap-1 inline-flex ${className}`}>
-      <picture className="relative w-6 h-6">
-        <img className="w-6 h-6" src={iconsrc} />
-        {/* src 변수로 가져오기 */}
-      </picture>
-      <div className="text-black text-[15px] font-semibold">{text}</div>
-      {/* div 안 내용 변수로 가져오기 */}
+    <div className={`h-6 items-left gap-4 inline-flex ${className}`}>
+      <Image className="relative w-6 h-6" src={iconsrc}></Image>
+      <div>{text}</div>
     </div>
   );
 };

--- a/src/components/molecules/BayItem.jsx
+++ b/src/components/molecules/BayItem.jsx
@@ -2,7 +2,14 @@ import React from "react";
 import dayjs from "dayjs";
 import TimeSlot from "../atoms/TimeSlot";
 
-const BayItem = ({ bayNo, bayBookedTime, openingHours, selectedDate }) => {
+const BayItem = ({
+  bayId,
+  bayNo,
+  bayBookedTime,
+  openingHours,
+  selectedDate,
+  onClick,
+}) => {
   const getCurrentHour = () =>
     Math.max(
       dayjs().hour(),
@@ -28,7 +35,10 @@ const BayItem = ({ bayNo, bayBookedTime, openingHours, selectedDate }) => {
   const closingHour = getClosingHour();
 
   return (
-    <div className="py-4 overflow-x-auto border border-gray-300 rounded-xl">
+    <div
+      className="py-4 overflow-x-auto border border-gray-300 cursor-pointer rounded-xl"
+      onClick={() => onClick(bayId)}
+    >
       <div className="p-2 font-semibold">베이 {bayNo}</div>
       <div className="flex justify-center px-4">
         <TimeSlot

--- a/src/components/molecules/CarwashCard.jsx
+++ b/src/components/molecules/CarwashCard.jsx
@@ -1,9 +1,12 @@
 import React from "react";
-import Image from "/RecentCarwashItem/image.png";
 import Star from "../atoms/Star";
 import DistanceFromHere from "../atoms/DistanceFromHere";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { setCarwashId } from "../../store/action";
 
 export const CarwashCard = ({
+  id,
   image,
   name,
   address,
@@ -11,8 +14,19 @@ export const CarwashCard = ({
   reviewCount,
   distance,
 }) => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const handleClick = () => {
+    dispatch(setCarwashId(id));
+    navigate(`/carwashdetail/${id}`);
+  };
+
   return (
-    <div className="relative w-auto overflow-hidden shadow-xl h-72 rounded-xl">
+    <div
+      className="relative w-auto overflow-hidden shadow-xl h-72 rounded-xl"
+      onClick={handleClick}
+    >
       <img src={image} alt={name} className="absolute top-0 object-cover" />
       <div className="absolute bottom-0 z-50 justify-between w-full h-24 p-4 bg-white">
         <div className="relative">

--- a/src/components/molecules/ReservationItem.jsx
+++ b/src/components/molecules/ReservationItem.jsx
@@ -36,31 +36,21 @@ const ReservationItem = ({
   }, [showCancelSheet]);
 
   return (
-    <div className="w-auto h-24 relative bg-white rounded-xl border border-gray-200 flex items-center gap-3.5 ">
-      {/* 세차장 사진 부분 */}
-      <Image
-        src={imgsrc}
-        className="flex  w-[74px] h-[74px] rounded-xl ml-3"
-        alt="세차장 이미지"
-      />
-
-      <div className="flex flex-col w-56 h-16 gap-1">
-        <div className="text-sm text-gray-400">{reservetime}</div>
-        <div className="font-semibold ">{bayname}</div>
-        <div className="left-0 top-[53px] text-primary text-sm  ">
-          {priceinfo}
-        </div>
+    <div className="flex justify-between py-4 overflow-x-auto border border-gray-300 rounded-xl">
+      <Image src={imgsrc} className="w-24 h-16 m-2 " alt="세차장 이미지" />
+      <div className="flex flex-col gap-2">
+        <div className="text-sm text-gray-500">{reservetime}</div>
+        <div>{bayname}</div>
+        <div className="text-right text-primary">{priceinfo}</div>
       </div>
-
-      {buttontype === "cancel" && (
-        <Button
-          type="cancel"
-          onClick={() => setShowCancelSheet(true)}
-          label="예약취소"
-        />
-      )}
-
-      {buttontype === "review" && <Button type="review" label="리뷰 작성" />}
+      <div>
+        {buttontype === "cancel" && (
+          <Button variant="cancel" onClick={() => setShowCancelSheet(true)}>
+            예약 취소
+          </Button>
+        )}
+      </div>
+      {buttontype === "review" && <Button variant="review"> 리뷰 작성 </Button>}
 
       {showCancelSheet && (
         <div ref={cancelSheetRef} className="fixed left-0 bottom-[60px] z-10">

--- a/src/components/organisms/BayList.jsx
+++ b/src/components/organisms/BayList.jsx
@@ -1,17 +1,19 @@
+// BayList.js
 import React from "react";
 import BayItem from "../molecules/BayItem";
 
-const BayList = ({ bays, openingHours, selectedDate }) => {
+const BayList = ({ bays, openingHours, selectedDate, onClick }) => {
   return (
     <div className="grid gap-2">
-      {bays.map((item, index) => (
+      {bays.map((item) => (
         <BayItem
-          key={index}
+          key={item.bayId}
           bayId={item.bayId}
           bayNo={item.bayNo}
           bayBookedTime={item.bayBookedTime}
           openingHours={openingHours}
           selectedDate={selectedDate}
+          onClick={() => onClick(item.bayId)} // Pass bayId to onClick
         />
       ))}
     </div>

--- a/src/components/organisms/LoginForm.jsx
+++ b/src/components/organisms/LoginForm.jsx
@@ -33,7 +33,8 @@ const LoginForm = () => {
             console.error(error);
           },
         });
-      })}>
+      })}
+    >
       <TextInput
         type="email"
         placeholder="이메일"

--- a/src/components/templates/BaySelectionTemplate.jsx
+++ b/src/components/templates/BaySelectionTemplate.jsx
@@ -5,6 +5,7 @@ import BayList from "../organisms/BayList";
 import { useEffect, useState } from "react";
 import { carwashesBays } from "../../apis/carwashes";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useDispatch } from "react-redux";
 
 const BaySelectionTemplate = ({}) => {
   const name = "포세이돈워시 용봉점";
@@ -24,6 +25,12 @@ const BaySelectionTemplate = ({}) => {
     }
   }, []);
   // 세차장별 예약 내역 조회 '/carwashes/{carwash_id}/bays'
+
+  const dispatch = useDispatch();
+
+  const handleBayClick = (bayId) => {
+    dispatch({ type: "SET_BAY_ID", payload: bayId });
+  };
 
   return (
     <div className="relative p-4">
@@ -45,6 +52,8 @@ const BaySelectionTemplate = ({}) => {
           bays={bayList}
           openingHours={openingHours}
           selectedDate={new Date()}
+          onClick={handleBayClick}
+          // 여기서 해당 /schdule 링크로 이동해야함 (id값)
         />
       </div>
     </div>

--- a/src/components/templates/BaySelectionTemplate.jsx
+++ b/src/components/templates/BaySelectionTemplate.jsx
@@ -5,7 +5,8 @@ import BayList from "../organisms/BayList";
 import { useEffect, useState } from "react";
 import { carwashesBays } from "../../apis/carwashes";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 const BaySelectionTemplate = ({ carwashId }) => {
   const name = "포세이돈워시 용봉점";
@@ -14,10 +15,14 @@ const BaySelectionTemplate = ({ carwashId }) => {
     weekend: { start: "00:00", end: "24:00" },
   };
   const [bayList, setBayList] = useState([]);
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const selectedCarwashId = useSelector((state) => state.selectedCarwashId);
+
   const { data } = useSuspenseQuery({
-    queryKey: ["baylists", carwashId],
-    queryFn: () => carwashesBays(carwashId),
-    enabled: !!carwashId,
+    queryKey: ["baylists", selectedCarwashId],
+    queryFn: () => carwashesBays(selectedCarwashId),
+    enabled: !!selectedCarwashId,
   });
   console.log(data);
   useEffect(() => {
@@ -27,10 +32,9 @@ const BaySelectionTemplate = ({ carwashId }) => {
   }, []);
   // 세차장별 예약 내역 조회 '/carwashes/{carwash_id}/bays'
 
-  const dispatch = useDispatch();
-
   const handleBayClick = (bayId) => {
     dispatch({ type: "SET_BAY_ID", payload: bayId });
+    navigate(`/schedule/${selectedCarwashId}/${bayId}`);
   };
 
   return (

--- a/src/components/templates/CarwashDetailTemplate.jsx
+++ b/src/components/templates/CarwashDetailTemplate.jsx
@@ -4,17 +4,21 @@ import KeyPointInfo from "../atoms/KeyPointInfo";
 import { Button } from "../atoms/Button";
 import Star from "../atoms/Star";
 import { Tab } from "../molecules/Tab";
-
 import { useEffect, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { carwashesInfo } from "../../apis/carwashes";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 const CarwashDetailTemplate = ({ carwashId }) => {
   const [detaildata, setData] = useState(null);
+  const navigate = useNavigate();
+  const selectedCarwashId = useSelector((state) => state.selectedCarwashId);
+
   const { data } = useSuspenseQuery({
-    queryKey: ["getCarwashesInfo", carwashId], // add location to the dependency list to re-run query if location changes
-    queryFn: () => carwashesInfo(carwashId), // Pass location to the getcarwashes_nearby function
-    enabled: !!carwashId, // Only run the query when we have carwashid
+    queryKey: ["getCarwashesInfo", selectedCarwashId],
+    queryFn: () => carwashesInfo(selectedCarwashId),
+    enabled: !!selectedCarwashId,
   });
 
   useEffect(() => {
@@ -27,6 +31,10 @@ const CarwashDetailTemplate = ({ carwashId }) => {
   if (!detaildata) {
     return <div>Loading...</div>;
   }
+
+  const handleReservationClick = () => {
+    navigate(`/bayselection/${selectedCarwashId}`);
+  };
 
   const images = detaildata.image.map((url) => ({
     label: "Image",
@@ -74,7 +82,13 @@ const CarwashDetailTemplate = ({ carwashId }) => {
           </div>
         </div>
       </div>
-      <Button type="long" label="예약하기" className="fixed bottom-0" />
+      <Button
+        variant="long"
+        className="fixed bottom-0"
+        onClick={handleReservationClick}
+      >
+        예약하기
+      </Button>
     </div>
   );
 };

--- a/src/components/templates/CarwashDetailTemplate.jsx
+++ b/src/components/templates/CarwashDetailTemplate.jsx
@@ -13,6 +13,7 @@ const CarwashDetailTemplate = () => {
   const [detaildata, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [carwashesid, setCarwashid] = useState(3);
+  // 이름 통일 필요
 
   const { data } = useSuspenseQuery({
     queryKey: ["getCarwashesInfo", carwashesid], // add location to the dependency list to re-run query if location changes

--- a/src/components/templates/HomeTemplate.jsx
+++ b/src/components/templates/HomeTemplate.jsx
@@ -74,6 +74,7 @@ const HomeTemplate = () => {
       <section className="grid gap-4">
         <h2 className="text-xl font-semibold">이런 세차장 어때요?</h2>
         <CarwashCard
+          id={recommendedData.id}
           image={recommendedData.image}
           name={recommendedData.name}
           address={recommendedData.location.address}

--- a/src/components/templates/HomeTemplate.jsx
+++ b/src/components/templates/HomeTemplate.jsx
@@ -40,8 +40,6 @@ const HomeTemplate = () => {
   const recommendedData = recommended?.data?.data?.response;
   const recentList = recent?.data?.data?.response?.recent;
 
-  const navigate = useNavigate();
-
   return (
     <main className="grid gap-6">
       <h1 className="text-2xl font-semibold">노주영님 안녕하세요!</h1>

--- a/src/components/templates/PaymentResultTemplate.jsx
+++ b/src/components/templates/PaymentResultTemplate.jsx
@@ -4,6 +4,8 @@ import { Button } from "../atoms/Button";
 import { useEffect, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { reservations } from "../../apis/reservations";
+import { useDispatch } from "react-redux";
+import { resetStore } from "../../store/action";
 
 const iconsrc = {
   calendar: "/TextWithIcon/calendar.png",
@@ -15,6 +17,7 @@ const iconsrc = {
 const PaymentResultTemplate = () => {
   const [paymentresult, setpaymentresult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const dispatch = useDispatch();
 
   const { data } = useSuspenseQuery({
     queryKey: ["getReservations"],
@@ -27,6 +30,16 @@ const PaymentResultTemplate = () => {
       console.log(paymentresult);
     }
   }, [data]);
+
+  useEffect(() => {
+    // 페이지 로드 시 스토어를 초기 상태로 리셋
+    dispatch(resetStore());
+
+    if (data) {
+      setpaymentresult(data?.data?.response);
+      console.log(paymentresult);
+    }
+  }, [data, dispatch]);
 
   if (!paymentresult) {
     return <div>Loading...</div>;

--- a/src/components/templates/PaymentResultTemplate.jsx
+++ b/src/components/templates/PaymentResultTemplate.jsx
@@ -84,15 +84,17 @@ const PaymentResultTemplate = ({ reservationId }) => {
     <div>
       <div className="relative p-4">
         <div className="py-8 text-2xl font-bold"> 결제가 완료되었습니다!</div>
-        <div className="flex flex-col gap-4 py-4 rounded-lg bg-gray-50">
-          <TextWithIcon text={extractDay(start)} iconsrc={iconsrc.calendar} />
-          <TextWithIcon
-            text={`${extractTime(start)}~${extractTime(end)}`}
-            iconsrc={iconsrc.clock}
-          />
-          <TextWithIcon text={carwashname} iconsrc={iconsrc.location} />
-          <TextWithIcon text={`${price}원`} iconsrc={iconsrc.price} />
-          <MapWithPin lat={latitude} lng={longitude} text={carwashname} />
+        <div className="py-4 bg-gray-100 rounded-lg ">
+          <div className="flex flex-col gap-4 p-4">
+            <TextWithIcon text={extractDay(start)} iconsrc={iconsrc.calendar} />
+            <TextWithIcon
+              text={`${extractTime(start)}~${extractTime(end)}`}
+              iconsrc={iconsrc.clock}
+            />
+            <TextWithIcon text={carwashname} iconsrc={iconsrc.location} />
+            <TextWithIcon text={`${price}원`} iconsrc={iconsrc.price} />
+            <MapWithPin lat={latitude} lng={longitude} text={carwashname} />
+          </div>
         </div>
       </div>
       <Button

--- a/src/components/templates/PaymentResultTemplate.jsx
+++ b/src/components/templates/PaymentResultTemplate.jsx
@@ -6,18 +6,20 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { reservations } from "../../apis/reservations";
 import { useDispatch } from "react-redux";
 import { resetStore } from "../../store/action";
+import { useNavigate } from "react-router-dom";
 
 const iconsrc = {
   calendar: "/TextWithIcon/calendar.png",
-  clock: "TextWithIcon/clock.png",
-  location: "TextWithIcon/location.png",
-  price: "TextWithIcon/price.png",
+  clock: "/TextWithIcon/clock.png",
+  location: "/TextWithIcon/location.png",
+  price: "/TextWithIcon/price.png",
 };
 
 const PaymentResultTemplate = ({ reservationId }) => {
   const [paymentresult, setpaymentresult] = useState(null);
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const { data } = useSuspenseQuery({
     // 나중에 reservation api에 reservationId 추가 되면 이거로 코드 바꾸기
@@ -79,25 +81,27 @@ const PaymentResultTemplate = ({ reservationId }) => {
   };
 
   return (
-    <div className="relative grid gap-8">
-      <section className="grid gap-4">
-        <div className="text-2xl font-bold ">결제가 완료되었습니다!</div>
-        <div className="text-sm text-left">득광하세요!</div>
-      </section>
-      <section className="grid gap-4">
-        <TextWithIcon text={extractDay(start)} iconsrc={iconsrc.calendar} />
-        <hr />
-        <TextWithIcon
-          text={`${extractTime(start)}~${extractTime(end)}`}
-          iconsrc={iconsrc.clock}
-        />
-        <hr />
-        <TextWithIcon text={carwashname} iconsrc={iconsrc.location} />
-        <hr />
-        <TextWithIcon text={`${price}원`} iconsrc={iconsrc.price} />
-        <MapWithPin lat={latitude} lng={longitude} text={carwashname} />
-      </section>
-      <Button className="fixed bottom-0" label="홈으로" />
+    <div>
+      <div className="relative p-4">
+        <div className="py-8 text-2xl font-bold"> 결제가 완료되었습니다!</div>
+        <div className="flex flex-col gap-4 py-4 rounded-lg bg-gray-50">
+          <TextWithIcon text={extractDay(start)} iconsrc={iconsrc.calendar} />
+          <TextWithIcon
+            text={`${extractTime(start)}~${extractTime(end)}`}
+            iconsrc={iconsrc.clock}
+          />
+          <TextWithIcon text={carwashname} iconsrc={iconsrc.location} />
+          <TextWithIcon text={`${price}원`} iconsrc={iconsrc.price} />
+          <MapWithPin lat={latitude} lng={longitude} text={carwashname} />
+        </div>
+      </div>
+      <Button
+        variant="long"
+        className="fixed bottom-0"
+        onClick={() => navigate("/")}
+      >
+        홈으로
+      </Button>
     </div>
   );
 };

--- a/src/components/templates/PaymentTemplate.jsx
+++ b/src/components/templates/PaymentTemplate.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { paymentResult } from "../../apis/reservations";
 

--- a/src/components/templates/ReservationHistoryTemplate.jsx
+++ b/src/components/templates/ReservationHistoryTemplate.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import ReservationItem from "../molecules/ReservationItem";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { reservationsCurrentstatus } from "../../apis/reservations";
+import dayjs from "dayjs";
 
 const ReservationHistoryTemplate = () => {
   const [currentReservations, setCurrentReservations] = useState([]);
@@ -23,71 +24,74 @@ const ReservationHistoryTemplate = () => {
   }, [data]);
 
   const formatTimestamp = (timestamp) => {
-    const date = new Date(timestamp);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    const hours = String(date.getHours()).padStart(2, "0");
-    const minutes = String(date.getMinutes()).padStart(2, "0");
-
-    return `${year}-${month}-${day} ${hours}:${minutes}`;
+    return {
+      date: dayjs(timestamp).format("YYYY/MM/DD"),
+      time: dayjs(timestamp).format("HH시 mm분"),
+    };
   };
 
   const formatTime = (timestamp) => {
-    const date = new Date(timestamp);
-    const hours = String(date.getHours()).padStart(2, "0");
-    const minutes = String(date.getMinutes()).padStart(2, "0");
-
-    return `${hours}:${minutes}`;
+    return dayjs(timestamp).format("HH시 mm분");
   };
 
   return (
-    <div className="grid gap-10">
-      <div className="text-2xl font-bold">예약내역</div>
+    <div className="relative p-4">
+      <div className="flex-grow pb-12 overflow-y-scroll">
+        <div className="py-4 text-2xl font-bold text-primary">예약내역</div>
 
-      <div className="grid gap-2">
-        <div className="font-semibold">현재 진행중인 세차</div>
+        <div className="py-4 font-semibold">현재 진행중인 세차</div>
         {currentReservations.map((reservation) => (
           <ReservationItem
             key={reservation.id}
             bayid={reservation.id}
-            imgsrc={reservation.image} // Replace this with actual image URL if available in data
-            reservetime={`${formatTimestamp(
-              reservation.time.start
-            )} ~ ${formatTime(reservation.time.end)}`}
-            bayname={`${reservation.carwashName} : 베이${reservation.bayNum}`}
+            imgsrc={reservation.image}
+            reservetime={
+              <>
+                {formatTimestamp(reservation.time.start).date}
+                <br />
+                {formatTimestamp(reservation.time.start).time} -{" "}
+                {formatTime(reservation.time.end)}
+              </>
+            }
+            bayname={`${reservation.carwashName} 베이${reservation.bayNum}`}
             priceinfo={`${reservation.price}원`}
           />
         ))}
-      </div>
-
-      <div className="grid gap-2">
-        <div className="font-semibold">예정된 세차</div>
+        <hr className="mt-8" />
+        <div className="py-4 font-semibold">예정된 세차</div>
         {upcomingReservations.map((reservation) => (
           <ReservationItem
             key={reservation.id}
             bayid={reservation.id}
-            imgsrc={reservation.image} // Replace this with actual image URL if available in data
-            reservetime={`${formatTimestamp(
-              reservation.time.start
-            )} ~ ${formatTime(reservation.time.end)}`}
+            imgsrc={reservation.image}
+            reservetime={
+              <>
+                {formatTimestamp(reservation.time.start).date}
+                <br />
+                {formatTimestamp(reservation.time.start).time} -{" "}
+                {formatTime(reservation.time.end)}
+              </>
+            }
             bayname={`${reservation.carwashName} : 베이${reservation.bayNum}`}
             priceinfo={`${reservation.price}원`}
             buttontype="cancel"
           />
         ))}
-      </div>
-
-      <div className="grid gap-2">
-        <div className="font-semibold">완료한 세차</div>
+        <hr className="mt-8" />
+        <div className="py-4 font-semibold">완료한 세차</div>
         {completedReservations.map((reservation) => (
           <ReservationItem
             key={reservation.id}
             bayid={reservation.id}
-            imgsrc={reservation.image} // Replace this with actual image URL if available in data
-            reservetime={`${formatTimestamp(
-              reservation.time.start
-            )} ~ ${formatTime(reservation.time.end)}`}
+            imgsrc={reservation.image}
+            reservetime={
+              <>
+                {formatTimestamp(reservation.time.start).date}
+                <br />
+                {formatTimestamp(reservation.time.start).time} -{" "}
+                {formatTime(reservation.time.end)}
+              </>
+            }
             bayname={`${reservation.carwashName} : 베이${reservation.bayNum}`}
             priceinfo={`${reservation.price}원`}
             buttontype="review"

--- a/src/components/templates/ReservationTemplate.jsx
+++ b/src/components/templates/ReservationTemplate.jsx
@@ -47,48 +47,50 @@ const ReservationTemplate = () => {
   };
   console.log(location);
   return (
-    <div>
-      <div className="flex items-end w-screen h-screen gap-0 bg-white">
-        <KakaoMap className="fixed absolute left-0 z-0 w-screen h-screen" />
-        <DualBottomsheet className="fixed left-0 z-10">
-          <Bottomsheet className="z-20 flex flex-col h-full gap-3 overflow-y-scroll">
-            <div className="flex flex-row gap-2">
-              <Badge
-                key="1"
-                label="하부세차"
-                onClick={() => {
-                  handleBadgeClick(1);
-                }}
-              />
-              <Badge
-                key="2"
-                label="폼건세차"
-                onClick={() => {
-                  handleBadgeClick(2);
-                }}
-              />
-              <Badge
-                key="3"
-                label="온수세차"
-                onClick={() => {
-                  handleBadgeClick(3);
-                }}
-              />
-            </div>
-            {washlists?.data?.response &&
-              washlists?.data?.response.map((item, index) => (
-                <StoreItem
-                  key={index}
-                  imgsrc={item.image}
-                  storename={item.name}
-                  starcount={item.star}
-                  reviewcount="0"
-                  priceinfo="15000/60분"
-                  distance={item.distance}
+    <div className="overflow-y-auto">
+      <div>
+        <div className="flex items-end w-screen h-screen gap-0 bg-white">
+          <KakaoMap className="fixed left-0 z-0 w-screen h-screen" />
+          <DualBottomsheet className="fixed left-0 z-10">
+            <Bottomsheet className="z-20 flex flex-col h-full gap-3 overflow-y-scroll">
+              <div className="flex flex-row gap-2">
+                <Badge
+                  key="1"
+                  label="하부세차"
+                  onClick={() => {
+                    handleBadgeClick(1);
+                  }}
                 />
-              ))}
-          </Bottomsheet>
-        </DualBottomsheet>
+                <Badge
+                  key="2"
+                  label="폼건세차"
+                  onClick={() => {
+                    handleBadgeClick(2);
+                  }}
+                />
+                <Badge
+                  key="3"
+                  label="온수세차"
+                  onClick={() => {
+                    handleBadgeClick(3);
+                  }}
+                />
+              </div>
+              {washlists?.data?.response &&
+                washlists?.data?.response.map((item, index) => (
+                  <StoreItem
+                    key={index}
+                    imgsrc={item.image}
+                    storename={item.name}
+                    starcount={item.star}
+                    reviewcount="0"
+                    priceinfo="15000/60분"
+                    distance={item.distance}
+                  />
+                ))}
+            </Bottomsheet>
+          </DualBottomsheet>
+        </div>
       </div>
     </div>
   );

--- a/src/components/templates/ScheduleTemplate.jsx
+++ b/src/components/templates/ScheduleTemplate.jsx
@@ -11,16 +11,11 @@ import {
   carwashesBays,
   bookCarwash,
 } from "../../apis/carwashes";
-
-import { useDispatch } from "react-redux";
-import { saveReservation } from "../../store/action";
-
-const ScheduleTemplate = () => {
+const ScheduleTemplate = ({ carwashId, bayId }) => {
   const [date, setDate] = useState(new Date());
   const [startTime, setStartTime] = useState();
   const [duration, setDuration] = useState();
   const navigate = useNavigate();
-  const dispatch = useDispatch();
   const [washinfo, bayinfo] = useSuspenseQueries({
     queries: [
       {
@@ -54,7 +49,6 @@ const ScheduleTemplate = () => {
       formattedStartTime,
       formattedEndTime,
     };
-    dispatch(saveReservation(formattedStartTime, formattedEndTime));
     mutation.mutate(payload);
   };
 

--- a/src/components/templates/ScheduleTemplate.jsx
+++ b/src/components/templates/ScheduleTemplate.jsx
@@ -11,6 +11,10 @@ import {
   carwashesBays,
   bookCarwash,
 } from "../../apis/carwashes";
+
+import { useDispatch } from "react-redux";
+import { saveReservation } from "../../store/action";
+
 const ScheduleTemplate = () => {
   const [date, setDate] = useState(new Date());
   const [startTime, setStartTime] = useState();
@@ -18,6 +22,7 @@ const ScheduleTemplate = () => {
   const [carwashId, setcarwashId] = useState(3);
   const [bayId, setbayId] = useState(0);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [washinfo, bayinfo] = useSuspenseQueries({
     queries: [
       {
@@ -51,6 +56,7 @@ const ScheduleTemplate = () => {
       formattedStartTime,
       formattedEndTime,
     };
+    dispatch(saveReservation(formattedStartTime, formattedEndTime));
     mutation.mutate(payload);
   };
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,9 @@ import App from "./App.jsx";
 import "./index.css";
 import { worker } from "./mocks/worker";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "react-redux";
+import { PersistGate } from "redux-persist/integration/react";
+import { store, persistor } from "./store";
 if (process.env.NODE_ENV === "development") {
   worker.start();
 }
@@ -11,8 +14,12 @@ const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </PersistGate>
+    </Provider>
   </React.StrictMode>
 );

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -541,7 +541,7 @@ export const handlers = [
               start: "2023-10-14T14:28:31.054667",
               end: "2023-10-14T15:28:31.054678",
             },
-            carwashName: "세차장",
+            carwashName: "용봉세차장",
             bayNum: 8,
             price: 5000,
             image:

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -536,7 +536,7 @@ export const handlers = [
       response: {
         current: [
           {
-            id: 10,
+            id: 2,
             time: {
               start: "2023-10-14T14:28:31.054667",
               end: "2023-10-14T15:28:31.054678",

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -251,12 +251,12 @@ export const handlers = [
           bayCnt: 4,
           optime: {
             weekday: {
-              start: "09:00:00",
-              end: "17:00:00",
+              start: "09:00",
+              end: "17:00",
             },
             weekend: {
-              start: "10:00:00",
-              end: "16:00:00",
+              start: "10:00",
+              end: "16:00",
             },
           },
           image: [

--- a/src/pages/ReservationHistoryPage.jsx
+++ b/src/pages/ReservationHistoryPage.jsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import ReservationHistoryTemplate from "../components/templates/ReservationHistroyTemplate.jsx";
+import ReservationHistoryTemplate from "../components/templates/ReservationHistoryTemplate.jsx";
 const ReservationHistoryPage = () => {
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/src/store/action.js
+++ b/src/store/action.js
@@ -1,0 +1,26 @@
+// 액션 타입 정의
+export const SET_CARWASH_ID = "SET_CARWASH_ID";
+export const SET_BAY_ID = "SET_BAY_ID";
+export const SAVE_RESERVATION = "SAVE_RESERVATION";
+export const RESET_STORE = "RESET_STORE";
+
+// 액션 생성자 정의
+
+export const setCarwashId = (carwashId) => ({
+  type: SET_CARWASH_ID,
+  payload: carwashId,
+});
+
+export const setBayId = (bayId) => ({
+  type: SET_BAY_ID,
+  payload: bayId,
+});
+
+export const saveReservation = (startTime, endTime) => ({
+  type: SAVE_RESERVATION,
+  payload: { startTime, endTime },
+});
+
+export const resetStore = () => ({
+  type: RESET_STORE,
+});

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,53 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { persistReducer, persistStore } from "redux-persist";
+import storage from "redux-persist/lib/storage";
+import {
+  SET_BAY_ID,
+  SAVE_RESERVATION,
+  SET_CARWASH_ID,
+  RESET_STORE,
+} from "./action";
+
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const initialState = {
+  selectedCarwashId: null,
+  selectedBayId: null,
+  reservations: [],
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_CARWASH_ID:
+      return { ...state, selectedCarwashId: action.payload };
+    case SET_BAY_ID:
+      return { ...state, selectedBayId: action.payload };
+    case SAVE_RESERVATION:
+      return {
+        ...state,
+        reservations: {
+          startTime: action.payload.startTime,
+          endTime: action.payload.endTime,
+        },
+      };
+    case RESET_STORE:
+      return initialState;
+    default:
+      return state;
+  }
+};
+
+const persistedReducer = persistReducer(persistConfig, reducer);
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
+});
+
+export const persistor = persistStore(store);


### PR DESCRIPTION
## Motivation
- 전역 상태 관리 (bayid, carwashid, starttime, endtime) 
- user repo 버그 수정 

## Key Changes
- redux 적용 
  - 메인 페이지에서 추천 세차장 클릭할 때 carwash_id 전역 상태로 저장 
  - 베이 선택 페이지에서 베이 클릭 시 bay_id 전역 상태로 저장 
  - 시간 선택 페이지에서 버튼 클릭 시 starttime, endtime 전역 상태로 저장 
  - 결제 완료 페이지에서 로드 후 로컬 스토리지에서 데이터 삭제 
  
- 스타일 수정 
  - 결제 완료 페이지 CSS
  - 예약 내역 페이지 CSS (하는 중)
  - 상세정보 페이지 CSS (캐러셀, 전화번호 하이픈)
  - 내주변 세차장 예약하기 페이지 내비게이션 바 위치 고정 
  
- 리다이렉트 
  - 추천 세차장 클릭 시 해당 세차장 상세정보로 이동 
  - 예약 내역 버튼 클릭 시 이동 
  - 상세정보 페이지 예약하기 버튼 클릭 시 베이 선택 페이지로 이동 

  
## To Reviewers
- Schedule 페이지 api 데이터가 제대로 안불러와지는 것 같음 해결하고 리다이렉트 해야함 
- Schedule 페이지에서 버튼 이름 (예약하기) 모호함 