### PR TITLE
fix:ReservationHistory에서 ReviewPost로 전역변수 넘기기

### DIFF
--- a/src/components/molecules/ReservationItem.jsx
+++ b/src/components/molecules/ReservationItem.jsx
@@ -1,22 +1,34 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "../atoms/Button";
 import Image from "../atoms/Image";
 import CustomModal from "../atoms/CustomModal";
 import { useMutation } from "@tanstack/react-query";
 import { cancelReservation } from "../../apis/reservations";
+import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 const ReservationItem = ({
-  bayid,
+  rsvid,
+  carwashid,
   imgsrc,
   reservetime,
   bayname,
   priceinfo,
   buttontype,
 }) => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  console.log(carwashid);
+  const handleBayClick = (rsvid, carwashid) => {
+    dispatch({ type: "SET_CARWASH_ID", payload: carwashid });
+    dispatch({ type: "SET_RESERVATION_ID", payload: rsvid });
+    navigate(`/reviewpost`);
+  };
+
   const mutation = useMutation({
-    mutationFn: (bayid) => cancelReservation(bayid),
+    mutationFn: (rsvid) => cancelReservation(rsvid),
     onSuccess: () => {
       console.log("예약 취소 성공");
       location.reload();
@@ -27,7 +39,7 @@ const ReservationItem = ({
   });
 
   const handleConfirm = () => {
-    mutation.mutate(bayid);
+    mutation.mutate(rsvid);
     setIsModalOpen(false);
   };
 
@@ -58,15 +70,20 @@ const ReservationItem = ({
         <Button
           variant="long"
           onClick={() => setIsModalOpen(true)}
-          className="bg-gray-500 rounded-md"
+          className=" bg-red-500 rounded-md"
         >
           예약 취소
         </Button>
       )}
       {buttontype === "review" && (
-        <Button variant="long" className="rounded-md">
+        <Button
+          variant="long"
+          className="rounded-md"
+          onClick={() => handleBayClick(rsvid, carwashid)}
+        >
           리뷰 작성
         </Button>
+        //<button onClick={handleBayClick(rsvid, carwashid)}>리뷰 작성 </button>
       )}
       <CustomModal
         isOpen={isModalOpen}

--- a/src/components/templates/ReservationHistoryTemplate.jsx
+++ b/src/components/templates/ReservationHistoryTemplate.jsx
@@ -43,7 +43,8 @@ const ReservationHistoryTemplate = () => {
         {currentReservations.map((reservation) => (
           <ReservationItem
             key={reservation.id}
-            bayid={reservation.id}
+            rsvid={reservation.id}
+            carwashid={reservation.carwashId}
             imgsrc={reservation.image}
             reservetime={
               <>
@@ -62,7 +63,8 @@ const ReservationHistoryTemplate = () => {
         {upcomingReservations.map((reservation) => (
           <ReservationItem
             key={reservation.id}
-            bayid={reservation.id}
+            carwashid={reservation.carwashId}
+            rsvid={reservation.id}
             imgsrc={reservation.image}
             reservetime={
               <>
@@ -82,7 +84,8 @@ const ReservationHistoryTemplate = () => {
         {completedReservations.map((reservation) => (
           <ReservationItem
             key={reservation.id}
-            bayid={reservation.id}
+            carwashid={reservation.carwashId}
+            rsvid={reservation.id}
             imgsrc={reservation.image}
             reservetime={
               <>

--- a/src/components/templates/ReviewPostTemplate.jsx
+++ b/src/components/templates/ReviewPostTemplate.jsx
@@ -5,7 +5,7 @@ import { BadgeSet } from "../molecules/BadgeSet";
 import { useNavigate } from "react-router-dom";
 import { Button } from "../atoms/Button";
 import { getReviews, postReviews } from "../../apis/carwashes";
-
+import { useSelector } from "react-redux";
 const ReviewPostTemplate = () => {
   const [keywords, setKeywords] = useState([]);
   const [selectedKeywords, setSelectedKeywords] = useState([]);
@@ -15,8 +15,8 @@ const ReviewPostTemplate = () => {
   const navigate = useNavigate();
 
   // 임의의 carwashId와 reservationId 설정
-  const carwashId = 1; // 실제 로직에 맞게 수정해야 합니다.
-  const reservationId = 1; // 실제 로직에 맞게 수정해야 합니다.
+  const carwashId = useSelector((state) => state.selectedCarwashId);
+  const reservationId = useSelector((state) => state.selectedReservationId);
 
   const { data } = useSuspenseQuery({
     queryKey: ["getCarwashesInfo"],
@@ -64,12 +64,9 @@ const ReviewPostTemplate = () => {
         value={comment}
         onChange={(e) => setComment(e.target.value)}
       />
-      <Button
-        label="후기등록"
-        onClick={handleSubmit}
-        type="reviewpost"
-        className="fixed bottom-0"
-      />
+      <Button variant="long" onClick={handleSubmit} className="fixed bottom-0">
+        리뷰 등록하기{" "}
+      </Button>
     </div>
   );
 };

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -45,6 +45,7 @@ export const MainLayout = () => {
   const [showLoginModal, setShowLoginModal] = useState(false);
 
   const noGNBPaths = [
+    "/reviewpost",
     "/schedule",
     "/carwashdetail",
     "/payment",

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -528,6 +528,7 @@ export const handlers = [
               start: "2023-10-14T14:28:31.054667",
               end: "2023-10-14T15:28:31.054678",
             },
+            carwashId: 3,
             carwashName: "용봉세차장",
             bayNum: 8,
             price: 5000,
@@ -540,6 +541,7 @@ export const handlers = [
               start: "2023-10-14T15:10:41.498809",
               end: "2023-10-14T15:40:41.498834",
             },
+            carwashId: 2,
             carwashName: "세차장",
             bayNum: 9,
             price: 4000,
@@ -552,6 +554,7 @@ export const handlers = [
               start: "2023-10-14T15:16:44.596950",
               end: "2023-10-14T15:46:44.596962",
             },
+            carwashId: 2,
             carwashName: "세차장",
             bayNum: 10,
             price: 4000,
@@ -566,6 +569,7 @@ export const handlers = [
               start: "2023-10-14T20:00:00",
               end: "2023-10-14T20:30:00",
             },
+            carwashId: 2,
             carwashName: "세차장",
             bayNum: 8,
             price: 4000,
@@ -576,10 +580,12 @@ export const handlers = [
         completed: [
           {
             id: 9,
+
             time: {
               start: "2023-10-14T14:28:30.958297",
               end: "2023-10-14T14:58:30.958325",
             },
+            carwashId: 2,
             carwashName: "세차장",
             bayNum: 10,
             price: 5000,
@@ -592,6 +598,7 @@ export const handlers = [
               start: "2023-10-14T06:00:00",
               end: "2023-10-14T06:30:00",
             },
+            carwashId: 2,
             carwashName: "세차장",
             bayNum: 10,
             price: 4000,

--- a/src/store/action.js
+++ b/src/store/action.js
@@ -1,6 +1,7 @@
 // 액션 타입 정의
 export const SET_CARWASH_ID = "SET_CARWASH_ID";
 export const SET_BAY_ID = "SET_BAY_ID";
+export const SET_RESERVATION_ID = "SET_RESERVATION_ID";
 export const SAVE_RESERVATION = "SAVE_RESERVATION";
 export const RESET_STORE = "RESET_STORE";
 
@@ -14,6 +15,11 @@ export const setCarwashId = (carwashId) => ({
 export const setBayId = (bayId) => ({
   type: SET_BAY_ID,
   payload: bayId,
+});
+
+export const setReservationId = (rsvId) => ({
+  type: SET_RESERVATION_ID,
+  payload: rsvId,
 });
 
 export const saveReservation = (startTime, endTime) => ({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import {
   SET_BAY_ID,
   SAVE_RESERVATION,
   SET_CARWASH_ID,
+  SET_RESERVATION_ID,
   RESET_STORE,
 } from "./action";
 
@@ -16,6 +17,7 @@ const persistConfig = {
 const initialState = {
   selectedCarwashId: null,
   selectedBayId: null,
+  selectedReservationId: null,
   reservations: [],
 };
 
@@ -25,6 +27,8 @@ const reducer = (state = initialState, action) => {
       return { ...state, selectedCarwashId: action.payload };
     case SET_BAY_ID:
       return { ...state, selectedBayId: action.payload };
+    case SET_RESERVATION_ID:
+      return { ...state, selectedReservationId: action.payload };
     case SAVE_RESERVATION:
       return {
         ...state,


### PR DESCRIPTION
## ReservationHistoryPage에서 ReviewPostPage로 전역변수 넘기기

### 바꿔야 할 컴포넌트

`ReservationItem`

- 리뷰작성 버튼을 onClick 시 전역변수에 저장하기
    - 전역변수에 저장하는 방법
    `action.js` 에서 액션 생성자, 타입 정의하기
    - 클릭 시 전역변수를 넘기는 방법
    `handleBayClick` 생성, `reservationId` `carwashid`  받아서 dispatch, navigate

## ReviewPost 페이지에서 post 하는 mockapi

- 기존 임의로 설정한 것에서 전역변수 참고하여 post