### PR TITLE
Feat/paymentwaiting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,14 +33,8 @@ function App() {
           />
           <Route path="schedule/:carwashId/:bayId" element={<SchedulePage />} />
           <Route path="payment" element={<PaymentPage />} />
-          <Route
-            path="paymentwaiting/:token"
-            element={<PaymentWaitingPage />}
-          />
-          <Route
-            path="paymentresult/:reservationId"
-            element={<PaymentResultPage />}
-          />
+          <Route path="paymentwaiting" element={<PaymentWaitingPage />} />
+          <Route path="paymentresult" element={<PaymentResultPage />} />
           <Route path="reviewpost" element={<ReviewPostPage />} />
         </Route>
         <Route path="login" element={<LoginPage />} />

--- a/src/apis/payment.js
+++ b/src/apis/payment.js
@@ -5,5 +5,5 @@ export const pgpayment = (carwash_id, data) => {
 };
 
 export const pgapprove = (carwash_id, bay_id) => {
-  return instance.get(`/api/payment/approve/${carwash_id}/${bay_id}`);
+  return instance.post(`/api/payment/approve/${carwash_id}/${bay_id}`);
 };

--- a/src/apis/payment.js
+++ b/src/apis/payment.js
@@ -4,6 +4,6 @@ export const pgpayment = (carwash_id, data) => {
   return instance.post(`/api/payment/ready/${carwash_id}`, data);
 };
 
-export const pgapprove = (carwash_id, bay_id) => {
-  return instance.post(`/api/payment/approve/${carwash_id}/${bay_id}`);
+export const pgapprove = (carwash_id, bay_id, data) => {
+  return instance.post(`/api/payment/approve/${carwash_id}/${bay_id}`, data);
 };

--- a/src/components/templates/PaymentResultTemplate.jsx
+++ b/src/components/templates/PaymentResultTemplate.jsx
@@ -6,7 +6,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { reservations } from "../../apis/reservations";
 import { useDispatch } from "react-redux";
 import { resetStore } from "../../store/action";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+
 import dayjs from "dayjs";
 
 const iconsrc = {
@@ -16,36 +17,47 @@ const iconsrc = {
   price: "/TextWithIcon/price.png",
 };
 
-const PaymentResultTemplate = ({ reservationId }) => {
+const PaymentResultTemplate = () => {
   const [paymentresult, setpaymentresult] = useState(null);
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-
-  const { data } = useSuspenseQuery({
-    // 나중에 reservation api에 reservationId 추가 되면 이거로 코드 바꾸기
-    // queryKey: ["getReservations", reservationId],
-    // queryFn: () => reservations(reservationId),
-    queryKey: ["getReservations"],
-    queryFn: () => reservations(),
-  });
-
-  useEffect(() => {
-    if (data) {
-      setpaymentresult(data?.data?.response);
-      console.log(paymentresult);
-    }
-  }, [data]);
+  const location = useLocation();
+  const { reservationData } = location.state || {};
+  // const reservationData = {
+  //   reservation: {
+  //     reservationId: 1,
+  //     time: {
+  //       start: "2023-11-01T12:00:00",
+  //       end: "2023-11-01T13:00:00",
+  //     },
+  //     price: 6000,
+  //     bayNo: 1,
+  //   },
+  //   carwash: {
+  //     name: "구름 세차장",
+  //     location: {
+  //       latitude: 35.1502,
+  //       longitude: 126.9167,
+  //     },
+  //     carwashImages: [
+  //       {
+  //         id: 1,
+  //         name: "image1.jpg",
+  //         url: "http://example.com/image1.jpg",
+  //         path: "/images/image1.jpg",
+  //         uploadedAt: "2023-10-24T10:00:00",
+  //       },
+  //     ],
+  //   },
+  // };
+  console.log(reservationData);
 
   useEffect(() => {
     dispatch(resetStore());
-    if (data) {
-      setpaymentresult(data?.data?.response);
-      console.log(paymentresult);
-    }
-  }, [data, dispatch]);
+  }, [dispatch]);
 
-  if (!paymentresult) {
+  if (!reservationData) {
     return <div>Loading...</div>;
   }
 
@@ -53,12 +65,15 @@ const PaymentResultTemplate = ({ reservationId }) => {
     reservation: {
       time: { start, end },
       price,
+      reservationId,
+      bayNo,
     },
     carwash: {
       name: carwashname,
       location: { latitude, longitude },
     },
-  } = paymentresult;
+  } = reservationData;
+  console.log(latitude);
 
   const formatTime = (dateTime) => {
     return dayjs(dateTime).format("HH시 mm분");

--- a/src/components/templates/PaymentTemplate.jsx
+++ b/src/components/templates/PaymentTemplate.jsx
@@ -2,45 +2,96 @@ import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useSuspenseQuery, useMutation } from "@tanstack/react-query";
 import { calculatePayment } from "../../apis/carwashes";
+import { pgpayment } from "../../apis/payment";
 import dayjs from "dayjs";
 import { Button } from "../atoms/Button";
 import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 
 const PaymentTemplate = () => {
   const [paymentData, setPaymentData] = useState({ price: undefined });
+  const [redirectLink, setRedirectLink] = useState(null);
   const reservations = useSelector((state) => state.reservations);
-  const carwashId = useSelector((state) => state.selectedCarwashId); // CamelCase를 사용하여 변수명을 수정했습니다.
+  const carwashId = useSelector((state) => state.selectedCarwashId);
+  const bayId = useSelector((state) => state.selectedBayId);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
-  const { mutate, data, isLoading, isError, error } = useMutation({
+  const {
+    mutate: paymentCalMutate, //결제 금액 계산
+    isLoading: paymentCalIsLoading,
+    isError: paymentCalIsError,
+    error: paymentCalError,
+  } = useMutation({
     mutationFn: (data) => calculatePayment(carwashId, data),
     onSuccess: (data) => {
-      // 결제 성공 후 data를 상태에 설정합니다.
-      setPaymentData({ price: data.data.response.price }); // 이렇게 해서 반환된 결제 정보를 상태에 저장할 수 있습니다.
-      console.log("Payment successful with data:", data.data.response.price);
-      // 다음의 라인은 성공적인 결제 후에 필요한 로직을 처리합니다.
+      setPaymentData({ price: data.data.response.price });
+      console.log("결제금액 계산 성공:", data.data.response.price);
     },
     onError: (err) => {
-      console.error("Payment error:", err);
-      // navigate('/payment-error'); // 필요하다면 에러 페이지로 리디렉트할 수 있습니다.
+      console.error("결제금액 계산 error:", err);
     },
   });
 
+  const {
+    mutate: payMutate, // pg 결제 로직
+    isLoading: payIsLoading,
+    isError: payIsError,
+    error: payError,
+  } = useMutation({
+    mutationFn: (data) => pgpayment(carwashId, data),
+    onSuccess: (data) => {
+      console.log("data", data);
+      dispatch({ type: "SAVE_CID", payload: data.data.response.tid });
+      // 이제 setRedirectLink를 사용하여 리다이렉트 URL을 상태로 설정합니다.
+      setRedirectLink(data.data.response.next_redirect_mobile_url);
+    },
+    onError: (err) => {
+      console.error("Payment error:", err);
+    },
+  });
+  useEffect(() => {
+    if (redirectLink) {
+      // redirectLink가 설정되면, 네비게이트를 사용하여 리디렉션합니다.
+      window.location.href = redirectLink;
+    }
+  }, [redirectLink]);
+
+  const handlePayment = () => {
+    const paypostData = {
+      requestDto: {
+        cid: "TC0ONETIME",
+        partner_order_id: "partner_order_id",
+        partner_user_id: "partner_user_id",
+        item_name: "구름 세차장 예약",
+        quantity: 1,
+        tax_free_amount: 0,
+      },
+      saveDTO: {
+        bayId: bayId, // 전역 상태에서 bayId 가져오기
+        startTime: reservations.startTime, // 전역 상태에서 startTime 가져오기
+        endTime: reservations.endTime, // 전역 상태에서 endTime 가져오기
+      },
+    };
+    if (carwashId) {
+      payMutate(paypostData);
+    }
+  };
+
   useEffect(() => {
     if (reservations && carwashId) {
-      // mutate를 호출할 때 reservations 객체 전체를 data로 전달합니다.
-      mutate(reservations);
+      paymentCalMutate(reservations);
     }
-  }, [reservations, carwashId, mutate]);
+  }, [reservations, carwashId, paymentCalMutate]);
 
   // UI 로딩 상태 표시
-  if (isLoading) {
+  if (paymentCalIsLoading) {
     return <div>Loading...</div>;
   }
 
   // UI 에러 상태 표시
-  if (isError) {
-    return <div>Error: {error.message}</div>;
+  if (paymentCalIsLoading) {
+    return <div>Error: {paymentCalError.message}</div>;
   }
 
   const formatDateStart = (dateString) => {
@@ -98,7 +149,7 @@ const PaymentTemplate = () => {
       <Button
         variant="long"
         className="fixed bottom-0 left-0"
-        //onClick={() => navigate(`paymentresult/${reservationId}`)}
+        onClick={handlePayment}
       >
         {paymentAmount}원 결제하기
       </Button>

--- a/src/components/templates/PaymentTemplate.jsx
+++ b/src/components/templates/PaymentTemplate.jsx
@@ -42,7 +42,7 @@ const PaymentTemplate = () => {
     mutationFn: (data) => pgpayment(carwashId, data),
     onSuccess: (data) => {
       console.log("data", data);
-      dispatch({ type: "SAVE_CID", payload: data.data.response.tid });
+      dispatch({ type: "SAVE_TID", payload: data.data.response.tid });
       // 이제 setRedirectLink를 사용하여 리다이렉트 URL을 상태로 설정합니다.
       setRedirectLink(data.data.response.next_redirect_mobile_url);
     },

--- a/src/components/templates/PaymentWaitingTemplate.jsx
+++ b/src/components/templates/PaymentWaitingTemplate.jsx
@@ -1,11 +1,85 @@
 import { Button } from "../atoms/Button";
+import { useSelector, useDispatch } from "react-redux";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { pgapprove } from "../../apis/payment";
+
 const PaymentWaitingTemplate = () => {
+  // useDispatch와 useNavigate를 컴포넌트 최상위에 호출합니다.
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const pgToken = queryParams.get("pg_token");
+
+  // useSelector를 이용해 store에서 필요한 상태를 가져옵니다.
+  const bayId = useSelector((state) => state.selectedBayId);
+  const carwashId = useSelector((state) => state.selectedCarwashId);
+  const reservations = useSelector((state) => state.reservations);
+  const tid = useSelector((state) => state.tid);
+
+  // useMutation 훅을 이용해 결제 승인 로직을 설정합니다.
+  const {
+    mutate: approveMutate, // 결제 승인 요청 함수
+    isLoading: approveIsLoading,
+    isError: approveIsError,
+    error: approveError,
+  } = useMutation({
+    mutationFn: (data) => pgapprove(carwashId, bayId, data), // 결제 승인 API 함수
+    onSuccess: (data) => {
+      // 성공 시 작업
+      console.log("data:", data);
+      // navigate 등의 추가 작업을 여기에서 할 수 있습니다.
+    },
+    onError: (err) => {
+      // 오류 시 작업
+      console.error("error:", err);
+    },
+  });
+
+  // 결제 승인 요청을 처리하는 함수
+  const handlePayment = () => {
+    // 필요한 데이터를 생성합니다.
+    const approvepostData = {
+      payApprovalRequestDTO: {
+        cid: "TC0ONETIME",
+        tid: "T548fd612b8b1abba15f",
+        partner_order_id: "partner_order_id",
+        partner_user_id: "partner_user_id",
+        pg_token: pgToken,
+      },
+      saveDTO: {
+        bayId: bayId,
+        startTime: reservations.startTime,
+        endTime: reservations.endTime,
+      },
+      carwashId: carwashId,
+      bayId: bayId,
+    };
+
+    // 컨디션에 따라 결제 승인 요청을 보냅니다.
+    if (carwashId) {
+      // carwashId와 tid 가 유효한 경우에만 요청
+      approveMutate(approvepostData);
+    }
+  };
+
+  // JSX 리턴
   return (
     <div>
       <div>결제가 진행중입니다....!</div>
-      <Button variant="long" className="fixed bottom-0 left-0">
+      <Button
+        variant="long"
+        className="fixed bottom-0 left-0"
+        onClick={handlePayment}
+      >
         결제가 완료되었으면 클릭하세요!
       </Button>
+      {/* 오류 메시지 표시 */}
+      {approveIsError && <p>오류가 발생했습니다: {approveError?.message}</p>}
+      {/* 로딩 상태 표시 */}
+      {approveIsLoading && <p>결제 처리 중...</p>}
     </div>
   );
 };

--- a/src/components/templates/PaymentWaitingTemplate.jsx
+++ b/src/components/templates/PaymentWaitingTemplate.jsx
@@ -21,19 +21,19 @@ const PaymentWaitingTemplate = () => {
 
   // useMutation 훅을 이용해 결제 승인 로직을 설정합니다.
   const {
-    mutate: approveMutate, // 결제 승인 요청 함수
+    mutate: approveMutate,
     isLoading: approveIsLoading,
     isError: approveIsError,
     error: approveError,
   } = useMutation({
-    mutationFn: (data) => pgapprove(carwashId, bayId, data), // 결제 승인 API 함수
+    mutationFn: (data) => pgapprove(carwashId, bayId, data),
     onSuccess: (data) => {
-      // 성공 시 작업
-      console.log("data:", data);
-      // navigate 등의 추가 작업을 여기에서 할 수 있습니다.
+      // 'data' 객체 내부의 'data' 프로퍼티를 '/reservation' 경로로 전달
+      console.log(data.data);
+      navigate("/paymentresult", { state: { reservationData: data.data } });
     },
     onError: (err) => {
-      // 오류 시 작업
+      // 오류 핸들링 로직
       console.error("error:", err);
     },
   });
@@ -44,7 +44,7 @@ const PaymentWaitingTemplate = () => {
     const approvepostData = {
       payApprovalRequestDTO: {
         cid: "TC0ONETIME",
-        tid: "T548fd612b8b1abba15f",
+        tid: "T549040851b66fd49c17", //나중에 api 수정되면 tid로 받기!
         partner_order_id: "partner_order_id",
         partner_user_id: "partner_user_id",
         pg_token: pgToken,

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -737,6 +737,31 @@ export const handlers = [
     );
   }),
 
+  rest.post("/api/payment/approve/:carwash_id/:bay_id", (req, res, ctx) => {
+    const token = req.headers.get("Authorization");
+    const { carwash_id, bay_id } = req.params;
+
+    if (!token) {
+      return res(
+        ctx.status(401),
+        ctx.json({ error: "인증되지 않았습니다. (토큰 없음)" })
+      );
+    }
+    return res(
+      ctx.status(200),
+      ctx.json({
+        success: true,
+        response: {
+          name: "포세이돈워시 용봉점",
+          bay_no: 2,
+          total_price: 30000,
+          reservation_time: "예약시간",
+        },
+        error: null,
+      })
+    );
+  }),
+
   // 결제 완료
   rest.get("/api/reservations/:reservation_id/payment", (req, res, ctx) => {
     const token = req.headers.get("Authorization");
@@ -754,10 +779,23 @@ export const handlers = [
       ctx.json({
         success: true,
         response: {
-          name: "포세이돈워시 용봉점",
-          bay_no: 2,
-          total_price: 30000,
-          reservation_time: "예약시간",
+          reservation: {
+            reservationId: 11,
+            time: {
+              start: "2024-11-01T14:00:00",
+              end: "2024-11-01T15:00:00",
+            },
+            price: 20000,
+            bayNo: 1,
+          },
+          carwash: {
+            name: "전일 카 세차장",
+            location: {
+              latitude: 35.1806726203914,
+              longitude: 126.9707,
+            },
+            carwashImages: [],
+          },
         },
         error: null,
       })

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -702,10 +702,9 @@ export const handlers = [
   }),
 
   // 결제하기(PG)
-  rest.post("/api/reservations/:reservation_id/payment", (req, res, ctx) => {
+  rest.post("/api/payment/ready/:carwash_id", (req, res, ctx) => {
     const token = req.headers.get("Authorization");
-    const { reservation_id } = req.params;
-    const { selected_date, bay_id, start_time, end_time } = req.body;
+    const { carwash_id } = req.params;
 
     if (!token) {
       return res(
@@ -718,7 +717,21 @@ export const handlers = [
       ctx.status(200),
       ctx.json({
         success: true,
-        response: null,
+        response: {
+          tid: "T548bdcf2b8b1abb9fa4",
+          tms_result: false,
+          next_redirect_app_url:
+            "https://online-pay.kakao.com/mockup/v1/426e68070fe67dd6af122c4f402725475badbca9ffe20b56154e5f1f4abced40/aInfo",
+          next_redirect_mobile_url:
+            "https://online-pay.kakao.com/mockup/v1/426e68070fe67dd6af122c4f402725475badbca9ffe20b56154e5f1f4abced40/mInfo",
+          next_redirect_pc_url:
+            "https://online-pay.kakao.com/mockup/v1/426e68070fe67dd6af122c4f402725475badbca9ffe20b56154e5f1f4abced40/info",
+          android_app_scheme:
+            "kakaotalk://kakaopay/pg?url=https://online-pay.kakao.com/pay/mockup/426e68070fe67dd6af122c4f402725475badbca9ffe20b56154e5f1f4abced40",
+          ios_app_scheme:
+            "kakaotalk://kakaopay/pg?url=https://online-pay.kakao.com/pay/mockup/426e68070fe67dd6af122c4f402725475badbca9ffe20b56154e5f1f4abced40",
+          created_at: "2023-11-06T19:19:59",
+        },
         error: null,
       })
     );

--- a/src/pages/PaymentResultPage.jsx
+++ b/src/pages/PaymentResultPage.jsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { Suspense } from "react";
-import { useParams } from "react-router-dom";
 import PaymentResultTemplate from "../components/templates/PaymentResultTemplate.jsx";
 const PaymentResultPage = () => {
-  const { reservationId } = useParams(); //string
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <PaymentResultTemplate reservationId={reservationId} />
+      <PaymentResultTemplate />
     </Suspense>
   );
 };

--- a/src/store/action.js
+++ b/src/store/action.js
@@ -4,7 +4,7 @@ export const SET_BAY_ID = "SET_BAY_ID";
 export const SET_RESERVATION_ID = "SET_RESERVATION_ID";
 export const SAVE_RESERVATION = "SAVE_RESERVATION";
 export const RESET_STORE = "RESET_STORE";
-export const SAVE_CID = "SAVE_CID";
+export const SAVE_TID = "SAVE_TID";
 
 // 액션 생성자 정의
 
@@ -32,7 +32,7 @@ export const resetStore = () => ({
   type: RESET_STORE,
 });
 
-export const saveCid = (Cid) => ({
-  type: SAVE_CID,
-  payload: Cid,
+export const saveTid = (Tid) => ({
+  type: SAVE_TID,
+  payload: Tid,
 });

--- a/src/store/action.js
+++ b/src/store/action.js
@@ -4,6 +4,7 @@ export const SET_BAY_ID = "SET_BAY_ID";
 export const SET_RESERVATION_ID = "SET_RESERVATION_ID";
 export const SAVE_RESERVATION = "SAVE_RESERVATION";
 export const RESET_STORE = "RESET_STORE";
+export const SAVE_CID = "SAVE_CID";
 
 // 액션 생성자 정의
 
@@ -29,4 +30,9 @@ export const saveReservation = (startTime, endTime) => ({
 
 export const resetStore = () => ({
   type: RESET_STORE,
+});
+
+export const saveCid = (Cid) => ({
+  type: SAVE_CID,
+  payload: Cid,
 });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,7 +7,7 @@ import {
   SET_CARWASH_ID,
   SET_RESERVATION_ID,
   RESET_STORE,
-  SAVE_CID,
+  SAVE_TID,
 } from "./action";
 
 const persistConfig = {
@@ -20,6 +20,7 @@ const initialState = {
   selectedBayId: null,
   selectedReservationId: null,
   reservations: [],
+  tid: null,
 };
 
 const reducer = (state = initialState, action) => {
@@ -40,8 +41,8 @@ const reducer = (state = initialState, action) => {
       };
     case RESET_STORE:
       return initialState;
-    case SAVE_CID:
-      return { ...state, Cid: action.payload };
+    case SAVE_TID:
+      return { ...state, tid: action.payload };
     default:
       return state;
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ import {
   SET_CARWASH_ID,
   SET_RESERVATION_ID,
   RESET_STORE,
+  SAVE_CID,
 } from "./action";
 
 const persistConfig = {
@@ -39,6 +40,8 @@ const reducer = (state = initialState, action) => {
       };
     case RESET_STORE:
       return initialState;
+    case SAVE_CID:
+      return { ...state, Cid: action.payload };
     default:
       return state;
   }


### PR DESCRIPTION
저번 풀 리퀘 이후 주요 변경 사항
- 백엔드 <-> mock으로 구현한 것들 사이 차이 있으면 수정
- pg 요청을 구현하였으나, 현재 CORS 에러가 뜬 상태입니다. 확인 결과 request에 문제가 보이진 않아서,
올바른 응답의 예시를 mockdata로 만들어 로컬에서 제대로 동작하는지 확인하였습니다.

- response 내용에 대한 적절한 전역 변수 처리

- 간단한 승인 페이지를 만들고, 결제 후 승인하는 api를 적용하였습니다. 받은 값은 uselocation을 통해 paymentresult페이지로 건네주게 됩니다.

- paymentresult 페이지의 경로가 paymentresult/:reservationId 에서  paymentresult로 바뀌었습니다.
승인 api에서 response로 받은 값을 전부 건네주기 때문에, reservationId가 필요 없고, 기존 api도 사라졌기 때문입니다.


